### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,5 +1,8 @@
 name: Perform coverity scan
  
+permissions:
+  contents: read
+
 on: 
   push:
      branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jnidzwetzki/bboxdb/security/code-scanning/4](https://github.com/jnidzwetzki/bboxdb/security/code-scanning/4)

To address the issue, add a `permissions` block to the workflow file to explicitly define the least privileges necessary for the workflow. The `coverity-scan-action` seems to require access to repository contents for scanning and possibly write access for reporting results. However, we will start with `contents: read`, as it seems sufficient for the actions used in this workflow. If additional permissions are required, they can be added incrementally after verifying the workflow.

The changes should be made near the top of the workflow file, adding the `permissions` block either globally (applying to all jobs) or specifically to the `coverity` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
