### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build project
  
 on: [push]
  
+permissions:
+  contents: write
+ 
 jobs:
   compile:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/jnidzwetzki/bboxdb/security/code-scanning/3](https://github.com/jnidzwetzki/bboxdb/security/code-scanning/3)

To fix the issue, add a `permissions` key at the top level of the workflow. This will apply the permission settings to all jobs unless overridden by a job-specific `permissions` key. Based on the workflow's actions, the minimal permissions required are likely `contents: read` for checking out the code and `contents: write` for uploading coverage reports. These permissions should be explicitly defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
